### PR TITLE
Phase7 - 7.1 read specific post from cache first and then lookup the database.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,16 @@
 			<artifactId>spring-boot-starter-validation</artifactId>
 			<version>3.3.0</version>
 		</dependency>
+		<dependency>
+			<groupId>io.lettuce</groupId>
+			<artifactId>lettuce-core</artifactId>
+			<version>6.3.2.RELEASE</version>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.17.1</version>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/mide/gangsaeng/board/BoardServiceImpl.java
+++ b/src/main/java/com/mide/gangsaeng/board/BoardServiceImpl.java
@@ -1,26 +1,43 @@
 package com.mide.gangsaeng.board;
 
+import java.time.Duration;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mide.gangsaeng.bannedword.BannedWordService;
 import com.mide.gangsaeng.common.cursor.Cursor;
 import com.mide.gangsaeng.common.cursor.CursorBasedRequest;
 import com.mide.gangsaeng.common.cursor.CursorBasedResponse;
 
+import io.lettuce.core.SetArgs;
+import io.lettuce.core.api.sync.RedisCommands;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 public class BoardServiceImpl implements BoardService {
 
     public static final int MAX_VALUE_OF_PAGE_SIZE = 30;
     private final BoardRepository boardRepository;
     private final BannedWordService bannedWordService;
+    private final RedisCommands<String, String> redisCommands;
+    private final ObjectMapper objectMapper;
 
     @Autowired
-    public BoardServiceImpl(BoardRepository boardRepository, BannedWordService bannedWordService) {
+    public BoardServiceImpl(BoardRepository boardRepository,
+                            BannedWordService bannedWordService,
+                            RedisCommands<String, String> redisCommands,
+                            ObjectMapper objectMapper) {
         this.boardRepository = boardRepository;
         this.bannedWordService = bannedWordService;
+        this.redisCommands = redisCommands;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -31,7 +48,13 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     public BoardResponse read(long id) {
-        Board board = boardRepository.read(id);
+        Board board = fetchCachedBoard(id);
+
+        if (board == null) {
+            board = boardRepository.read(id);
+            cacheBoard(board);
+        }
+
         return BoardResponse.builder()
                 .id(board.getId())
                 .title(board.getTitle())
@@ -96,6 +119,42 @@ public class BoardServiceImpl implements BoardService {
         }
 
         return new CursorBasedResponse<>(page, new Cursor(prevCursor, nextCursor));
+    }
+
+    public void cacheBoard(Board board) {
+
+        try {
+            String boardValue = objectMapper.writeValueAsString(board);
+            final long boardId = board.getId();
+            redisCommands.set(makeBoardKey(boardId), boardValue, boardCachedDuration());
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    private Board fetchCachedBoard(long id) {
+        String boardRedisKey = makeBoardKey(id);
+        String boardValue = redisCommands.get(boardRedisKey);
+
+        if (boardValue == null) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(boardValue, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return null;
+    }
+
+    private SetArgs boardCachedDuration() {
+        return SetArgs.Builder.ex(Duration.ofMillis(10_000));
+    }
+
+    private String makeBoardKey(long id) {
+        return "board:" + id;
     }
 
     private boolean isRootCursor(CursorBasedRequest request) {

--- a/src/main/java/com/mide/gangsaeng/common/redis/LettuceConfig.java
+++ b/src/main/java/com/mide/gangsaeng/common/redis/LettuceConfig.java
@@ -1,0 +1,46 @@
+package com.mide.gangsaeng.common.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import jakarta.annotation.PreDestroy;
+
+@Configuration
+public class LettuceConfig {
+    private RedisClient redisClient;
+    private StatefulRedisConnection<String, String> connection;
+
+    @Bean
+    public RedisClient redisClient() {
+        return RedisClient.create(getRedisURI());
+    }
+
+    @Bean
+    public StatefulRedisConnection<String, String> connection(RedisClient redisClient) {
+        return redisClient.connect();
+    }
+
+    @Bean
+    public RedisCommands<String, String> syncCommands(StatefulRedisConnection<String, String> connection) {
+        return connection.sync();
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (connection != null) {
+            connection.close();
+        }
+
+        if (redisClient != null) {
+            redisClient.shutdown();
+        }
+    }
+
+    private RedisURI getRedisURI() {
+        return RedisURI.create("localhost", 6379);
+    }
+}

--- a/src/main/java/com/mide/gangsaeng/common/redis/LettuceConfig.java
+++ b/src/main/java/com/mide/gangsaeng/common/redis/LettuceConfig.java
@@ -1,5 +1,7 @@
 package com.mide.gangsaeng.common.redis;
 
+import java.time.Duration;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,18 +17,10 @@ public class LettuceConfig {
     private StatefulRedisConnection<String, String> connection;
 
     @Bean
-    public RedisClient redisClient() {
-        return RedisClient.create(getRedisURI());
-    }
-
-    @Bean
-    public StatefulRedisConnection<String, String> connection(RedisClient redisClient) {
-        return redisClient.connect();
-    }
-
-    @Bean
-    public RedisCommands<String, String> syncCommands(StatefulRedisConnection<String, String> connection) {
-        return connection.sync();
+    public RedisCommands<String, String> syncCommands() {
+        this.redisClient = RedisClient.create(getRedisURI());
+        this.connection = redisClient.connect();
+        return this.connection.sync();
     }
 
     @PreDestroy
@@ -41,6 +35,6 @@ public class LettuceConfig {
     }
 
     private RedisURI getRedisURI() {
-        return RedisURI.create("localhost", 6379);
+        return new RedisURI("localhost", 6379, Duration.ofSeconds(60));
     }
 }


### PR DESCRIPTION
Phase7.
Our service is suffering from large traffic in the storage layer. So we want to introduce a new cache layer.
Let’s use redis as cache with a “look aside” pattern.

note:
Please use [lettuce](https://lettuce.io/) library for redis in this project

7.1 
Let’s cache the post itself. So when user read specific post, this post should be read from cache first and then lookup the database if it does not exists in cache.

